### PR TITLE
Fix for issue Error in calling daast_from_file(filename). #21 . Made 'options' argument optional

### DIFF
--- a/da/compiler/parser.py
+++ b/da/compiler/parser.py
@@ -163,7 +163,7 @@ def extract_label(node):
     else:
         return None
 
-def daast_from_file(filename, args):
+def daast_from_file(filename, args=None):
     """Generates DistAlgo AST from source file.
 
     'filename' is the filename of source file. Optional argument 'args' is a


### PR DESCRIPTION
This change is the proposed fix for issue "Error in calling daast_from_file(filename). #21" on DistAlgo master branch.